### PR TITLE
Correction of description of Character Sets

### DIFF
--- a/doc/html/boost_regex/syntax/perl_syntax.html
+++ b/doc/html/boost_regex/syntax/perl_syntax.html
@@ -402,8 +402,8 @@
         sets</a>
       </h5>
 <p>
-        A character set is a bracket-expression starting with <code class="literal">[] and ending
-        with <code class="literal"></code></code>, it defines a set of characters, and matches
+        A character set is a bracket-expression starting with <code class="literal">[</code> and
+        ending with <code class="literal">]</code>, it defines a set of characters, and matches
         any single character that is a member of that set.
       </p>
 <p>


### PR DESCRIPTION
Correction of the first sentence of description of Characters Sets on Perl Regular Expression Syntax documentation page. This sentence is wrong in docs of library version 1.60.0 to 1.73.0. The sentence is correct in docs of library version 1.59.0 and former versions.